### PR TITLE
Add support for automated CI and code coverage.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: java
+jdk:
+  - oraclejdk7
+  - oraclejdk8
+  - openjdk7
+script:
+  - gradle check
+  - gradle jacocoTestReport
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://travis-ci.org/nnevolko/propmg.svg?branch=master)](https://travis-ci.org/nnevolko/propmg) [![codecov](https://codecov.io/gh/nnevolko/propmg/branch/master/graph/badge.svg)](https://codecov.io/gh/nnevolko/propmg)
 
 12/20/2016
 
@@ -18,5 +19,3 @@ Modify Maintenance Request
 2. Select Maintenance Request
 3. Modify information
 4. Save
-
-

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'java'
 apply plugin: 'war'
 apply plugin: 'eclipse'
+apply plugin: 'jacoco'
 
 repositories {
     mavenCentral()
@@ -11,4 +12,16 @@ dependencies {
     compile 'org.glassfish.jersey.containers:jersey-container-servlet:2.22.1'
 
     testCompile 'junit:junit:4.12'
+}
+
+test {
+    testLogging {
+        showStandardStreams true
+    }
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+    }
 }

--- a/src/test/java/com/nika/web/java/rest/JSONBasedReverserTest.java
+++ b/src/test/java/com/nika/web/java/rest/JSONBasedReverserTest.java
@@ -1,0 +1,41 @@
+package com.nika.web.java.rest;
+
+import javax.ws.rs.core.Response;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class JSONBasedReverserTest {
+
+    private JSONBasedReverser reverser;
+
+    @Before
+    public void setUp() {
+        reverser = new JSONBasedReverser();
+    }
+
+    @Test
+    public void testNoWord() {
+        JSONObject expected = new JSONObject();
+        expected.put("original", "ANKARA");
+        expected.put("reversed", "ARAKNA");
+        Response response = reverser.defaultReverser();
+        Assert.assertEquals(response.getStatus(), 200);
+        JSONObject actual = new JSONObject((String) response.getEntity());
+        Assert.assertEquals(actual.get("original"), expected.get("original"));
+        Assert.assertEquals(actual.get("reversed"), expected.get("reversed"));
+    }
+
+    @Test
+    public void testWord() {
+        JSONObject expected = new JSONObject();
+        expected.put("original", "foobar");
+        expected.put("reversed", "raboof");
+        Response response = reverser.reverser("foobar");
+        Assert.assertEquals(response.getStatus(), 200);
+        JSONObject actual = new JSONObject((String) response.getEntity());
+        Assert.assertEquals(actual.get("original"), expected.get("original"));
+        Assert.assertEquals(actual.get("reversed"), expected.get("reversed"));
+    }
+}


### PR DESCRIPTION
1. Added unit tests for the JSON reverser to verify CI and coverage results.
2. Modified the build.gradle to perform code coverage.
3. Added the Travis CI config to build and test an publish code coverage. The build will run on Oracle JDK 7, Oracle JDK 8, and Open JDK 7.
4. Added badges to the README to show up to date CI and coverage results.

If we decide to do this, you'll need to visit travis-ci.org and codecov.io and log in with your github acccount and enable CI and coverage for this repo.